### PR TITLE
Fix syntax errors for PHP < 7.3

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -49,7 +49,7 @@ class ArrayEngine extends Engine
 
             $this->store->set($model->searchableAs(), $model->getScoutKey(), array_merge(
                 $searchableData,
-                $model->scoutMetadata(),
+                $model->scoutMetadata()
             ));
         });
     }

--- a/src/Search.php
+++ b/src/Search.php
@@ -185,7 +185,7 @@ class Search
         Assert::assertEquals(
             0,
             $this->store->countInHistory(),
-            "Failed asserting that nothing was synced to search index.",
+            "Failed asserting that nothing was synced to search index."
         );
 
         return $this;
@@ -196,7 +196,7 @@ class Search
         Assert::assertEquals(
             0,
             $this->store->countInHistory($index),
-            "Failed asserting that nothing was synced to '{$index}' search index.",
+            "Failed asserting that nothing was synced to '{$index}' search index."
         );
 
         return $this;


### PR DESCRIPTION
As PHP version indicated in composer.json is 7.1, I removed trailing commas in function calls to avoid Fatal syntax errors.
Another solution would have been to bump PHP version to 7.3 in composer.json, but as I would like to use this package with PHP 7.2 I didn't take this option :).