### PR TITLE
Properly register classes

### DIFF
--- a/src/ScoutArrayEngineServiceProvider.php
+++ b/src/ScoutArrayEngineServiceProvider.php
@@ -9,22 +9,30 @@ use Sti3bas\ScoutArray\Engines\ArrayEngine;
 class ScoutArrayEngineServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any application services.
+     * Register services.
      *
      * @return void
      */
-    public function boot()
+    public function register()
     {
         $this->app->singleton(ArrayStore::class, function () {
             return new ArrayStore;
         });
 
-        $this->app[EngineManager::class]->extend('array', function ($app) {
-            return new ArrayEngine($this->app[ArrayStore::class], config('scout.soft_delete'));
-        });
-
         $this->app->bind(Search::class, function () {
             return new Search($this->app[ArrayStore::class]);
+        });
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot(EngineManager $engineManager)
+    {
+        $engineManager->extend('array', function () {
+            return new ArrayEngine($this->app[ArrayStore::class], config('scout.soft_delete'));
         });
     }
 }


### PR DESCRIPTION
This fixes an issue where the ScoutArrayEngineServiceProvider is called after the ScoutServiceProvider and the array driver in effect is not registered.

By following the ServiceProvider Documentation and only registering the singleton and bindings in the register method and extending Scout EngineManager in the boot method, this can be fixed.