### PR TITLE
Fixed Mockery expectations + faulty paginator

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -132,7 +132,7 @@ class ArrayEngine extends Engine
         $matches = Collection::make($matches);
 
         return [
-            'hits' => (isset($options['perPage']) ? $matches->slice(($options['page'] ?? 1) - 1, $options['perPage']) : $matches)->values()->all(),
+            'hits' => (isset($options['perPage']) ? $matches->slice((($options['page'] ?? 1) - 1) * $options['perPage'], $options['perPage']) : $matches)->values()->all(),
             'total' => $matches->count(),
         ];
     }

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -19,6 +19,7 @@ class ArrayEngineTest extends TestCase
     protected function setUp(): void
     {
         Config::shouldReceive('get')->with('scout.after_commit', Mockery::any())->andReturn(false);
+        Config::shouldReceive('get')->with('scout.soft_delete', Mockery::any())->andReturn(false);
     }
 
     protected function tearDown(): void
@@ -272,14 +273,20 @@ class ArrayEngineTest extends TestCase
         $engine->update(Collection::make([
             new SearchableModel(['foo' => 'bar', 'scoutKey' => 1]),
             new SearchableModel(['foo' => 'bar', 'scoutKey' => 2]),
-            new SearchableModel(['foo' => 'bar', 'scoutKey' => 3])
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 3]),
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 4]),
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 5]),
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 6]),
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 7]),
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 8]),
         ]));
 
-        $results = $engine->paginate(new Builder(new SearchableModel(), 'bar'), 1, 3);
+        $results = $engine->paginate(new Builder(new SearchableModel(), 'bar'), 2, 3);
 
-        $this->assertCount(1, $results['hits']);
-        $this->assertEquals(3, $results['total']);
-        $this->assertEquals(1, $results['hits'][0]['scoutKey']);
+        $this->assertCount(2, $results['hits']);
+        $this->assertEquals(8, $results['total']);
+        $this->assertEquals(4, $results['hits'][0]['scoutKey']);
+        $this->assertEquals(3, $results['hits'][1]['scoutKey']);
     }
 
     /** @test */


### PR DESCRIPTION
# What does this pull request fix?

## Mockery expectations
There was no Mockery expectation defined for `scout.softDelete` which caused the tests to fail. I added these the the `setUp()` method.

## Faulty paginator
The paginator had a bug that was undetected by the unit test. When using a page size larger than 1, the paginator would have an incorrect offset.

Instead of `paginate($startOffset, $numberOfItems)`, `paginate($pageNumber, $numberOfItems)` was used. This caused paged results to appear on more than one page, and pages to contain more items than they should actually contain.

This pull request fixes that behavior and the corresponding test.