### PR TITLE
Implement support for Array properties

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -3,6 +3,7 @@
 namespace Sti3bas\ScoutArray\Engines;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Laravel\Scout\Builder;
@@ -151,7 +152,7 @@ class ArrayEngine extends Engine
         }
 
         return Collection::make($filters)->every(function ($value, $key) use ($record) {
-            return $record[$key] === $value;
+            return in_array($value, Arr::wrap($record[$key]));
         });
     }
 

--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -152,7 +152,7 @@ class ArrayEngine extends Engine
         }
 
         return Collection::make($filters)->every(function ($value, $key) use ($record) {
-            return in_array($value, Arr::wrap($record[$key]));
+            return isset($record[$key]) && in_array($value, Arr::wrap($record[$key]));
         });
     }
 

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -56,6 +56,33 @@ class ArrayEngineTest extends TestCase
     }
 
     /** @test */
+    public function it_can_search_array_properties()
+    {
+        $engine = new ArrayEngine(new ArrayStore());
+        $engine->update(Collection::make([
+            new SearchableModel(['id' => 1, 'foo' => ['bar', 'baz', 'bak'], 'scoutKey' => '1']),
+            new SearchableModel(['id' => 2, 'foo' => ['bar', 'derp', 'meh'], 'scoutKey' => '2']),
+            new SearchableModel(['id' => 3, 'foo' => ['bak', 'bleh'], 'scoutKey' => '3']),
+        ]));
+
+        $builder = new Builder(new SearchableModel, '');
+        $builder->wheres['foo'] = 'derp';
+
+        $results = $engine->search($builder);
+
+        $this->assertCount(1, $results['hits']);
+        $this->assertEquals('2', $results['hits'][0]['objectID']);
+
+        $builder->wheres['foo'] = 'bak';
+
+        $results = $engine->search($builder);
+
+        $this->assertCount(2, $results['hits']);
+        $this->assertEquals('3', $results['hits'][0]['objectID']);
+        $this->assertEquals('1', $results['hits'][1]['objectID']);
+    }
+
+    /** @test */
     public function it_returns_all_results_if_no_query_provided()
     {
         $engine = new ArrayEngine(new ArrayStore());


### PR DESCRIPTION
# What does this pull request fix?

Laravel Scout has built-in support for array properties, but the array driver (ironically 😝 ) does not support searching properties with array values.

This pull request implements support for simple, flat arrays and will allow you to index and search models like this:

```php
public function toSearchableArray(): array
{
    return [
        'id' => $this->id,
        'categories' => [5, 6, 7]
    ];
}
```

**Searching:**

```php
$model->search()->where('category', 6);
```