### PR TITLE
Remove search callback call

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -111,16 +111,6 @@ class ArrayEngine extends Engine
     {
         $index = $builder->index ?: $builder->model->searchableAs();
 
-        if ($builder->callback) {
-            return call_user_func(
-                $builder->callback,
-                $this->store,
-                $index,
-                $builder->query,
-                $options
-            );
-        }
-
         $matches = $this->store->find($index, function ($record) use ($builder) {
             $values = new RecursiveIteratorIterator(new RecursiveArrayIterator($record));
 

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -90,31 +90,7 @@ class ArrayEngineTest extends TestCase
         $this->assertCount(2, $results['hits']);
         $this->assertEquals(3, $results['total']);
     }
-
-    /** @test */
-    public function callback_can_be_passed_to_search()
-    {
-        $arrayStore = new ArrayStore();
-        $engine = new ArrayEngine($arrayStore);
-        $engine->update(Collection::make([
-            new SearchableModel(['id' => 1, 'foo' => 'bar', 'scoutKey' => 1]),
-            new SearchableModel(['id' => 2, 'foo' => 'baz', 'scoutKey' => 2]),
-            new SearchableModel(['id' => 3, 'foo' => 'bar', 'scoutKey' => 3])
-        ]));
-
-        $wasCalled = false;
-        $builder = new Builder(new SearchableModel, 'bar', function ($store, $index, $query) use (&$wasCalled, $arrayStore) {
-            $wasCalled = true;
-            $this->assertSame($store, $arrayStore);
-            $this->assertEquals($index, (new SearchableModel())->searchableAs());
-            $this->assertEquals('bar', $query);
-        });
-
-        $engine->search($builder);
-
-        $this->assertTrue($wasCalled);
-    }
-    
+   
     /** @test */
     public function it_returns_empty_array_if_no_results_found()
     {


### PR DESCRIPTION
Fix the issue https://github.com/Sti3bas/laravel-scout-array-driver/issues/14

I'm still not sure why we need this. But this is currently broken when we use a callback as the method does not uses the same arguments and would need to add, at least, the `search` method in the store since it's being called in the callback (and potentially others methods given to the users by Algolia|Meilisearch clients).

Exemple of callback
```php
 // Currently, when running tests, $meilisearch is an instance of ArrayStore
App\Models\User::search('John Doe', function($meilisearch, string $query, array $options) {
    $options['sort'] = ['name:asc'];
    $options['filter'] = 'email IS NOT NULL';

    /** @var Meilisearch\Endpoints\Indexes $meilisearch */
    return $meilisearch->search($query, $options);
})->get();
```

See https://github.com/cbaconnier/laravel-scout-array-bug/commit/cdb3620abe1696497cc6cbdb702d64f2dffa4970 



~I also mentioned in the issue, as alternative, we could store the callback(s) to allow the users to tests them separately.~

```php
Search::assertSearchedWithCallback(function(Indexes $meiliSearch, string $query, array $options){
    return true;
}); 
```

But I haven't got the time to investigate how to adapt the `Store` for this.
What do you think?


Edit: 
I don't think we can't add `assertSearchedWithCallback` test since we cannot compare closure.
Or at least I have no knowledge of it.

