### PR TITLE
Laravel 11 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,4 @@ jobs:
           composer require "illuminate/bus:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" "illuminate/database:${{ matrix.laravel }}" "illuminate/http:${{ matrix.laravel }}" "illuminate/pagination:${{ matrix.laravel }}" "illuminate/queue:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
       - name: Execute tests
-        run: vendor/bin/phpunit --verbose
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-  pull_request:
-  schedule:
-    - cron: "0 0 * * *"
+#  pull_request:
+#  schedule:
+#    - cron: "0 0 * * *"
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,24 +8,23 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
-        php: ["8.0", 8.1, 8.2]
-        laravel: [9, 10]
+        os: [ubuntu-latest]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10.*, 11.*]
+        dependency-version: [prefer-lowest, prefer-stable]
         exclude:
-          - php: "8.0"
-            laravel: 9
-          - php: "8.0"
-            laravel: 10
+          - laravel: 11.*
+            php: 8.1
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -37,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
-          composer update --prefer-dist --no-interaction --no-progress
+          composer require "illuminate/bus:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" "illuminate/database:${{ matrix.laravel }}" "illuminate/http:${{ matrix.laravel }}" "illuminate/pagination:${{ matrix.laravel }}" "illuminate/queue:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-#  pull_request:
-#  schedule:
-#    - cron: "0 0 * * *"
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   tests:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 .phpunit.result.cache
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "laravel/scout": "^10.8"
   },
   "require-dev": {
+    "laravel/pint": "^1.13",
     "mockery/mockery": "^1.5.1",
     "phpunit/phpunit": "^10.0.7"
   },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "sti3bas/laravel-scout-array-driver",
   "description": "Array driver for Laravel Scout",
+  "license": "MIT",
   "keywords": [
     "array",
     "testing",
@@ -8,7 +9,6 @@
     "scout",
     "laravel"
   ],
-  "license": "MIT",
   "authors": [
     {
       "name": "Laurynas Geigalas",
@@ -16,15 +16,22 @@
     }
   ],
   "require": {
-    "php": "^8.0",
-    "laravel/scout": "^10.0",
-    "illuminate/database": "^8.0|^9.0|^10.0",
-    "illuminate/support": "^8.0|^9.0|^10.0"
+    "php": "^8.1",
+    "illuminate/bus": "^10.10.0 || ^11.0",
+    "illuminate/contracts": "^10.10.0 || ^11.0",
+    "illuminate/database": "^10.10.0 || ^11.0",
+    "illuminate/http": "^10.10.0 || ^11.0",
+    "illuminate/pagination": "^10.10.0 || ^11.0",
+    "illuminate/queue": "^10.10.0 || ^11.0",
+    "illuminate/support": "^10.10.0 || ^11.0",
+    "laravel/scout": "^10.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.3",
-    "mockery/mockery": "~1.0"
+    "mockery/mockery": "^1.5.1",
+    "phpunit/phpunit": "^10.0.7"
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "autoload": {
     "psr-4": {
       "Sti3bas\\ScoutArray\\": "src/"
@@ -35,12 +42,14 @@
       "Sti3bas\\ScoutArray\\Tests\\": "tests/"
     }
   },
+  "config": {
+    "sort-packages": true
+  },
   "extra": {
     "laravel": {
       "providers": [
         "Sti3bas\\ScoutArray\\ScoutArrayEngineServiceProvider"
       ]
     }
-  },
-  "prefer-stable": true
+  }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" 
+    	backupGlobals="false" 
+    	bootstrap="vendor/autoload.php" 
+		colors="true" 
+		processIsolation="false" 
+		stopOnFailure="false" 
+		cacheDirectory=".phpunit.cache" 
+		backupStaticProperties="false"
 >
-    <testsuites>
-        <testsuite name="Package Test Suite">
-            <directory suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
+  <testsuites>
+    <testsuite name="Package Test Suite">
+      <directory suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/ArrayStore.php
+++ b/src/ArrayStore.php
@@ -38,7 +38,7 @@ class ArrayStore
 
     public function deleteIndex(string $index): void
     {
-        $this->storage = Arr::except($this->storage, 'current.' . $index);
+        $this->storage = Arr::except($this->storage, 'current.'.$index);
     }
 
     public function indexExists(string $index): bool
@@ -66,12 +66,12 @@ class ArrayStore
         return $this->findInArray(Arr::get($this->storage['history'], $index, []), $callback);
     }
 
-    public function count(string $index = null, string $type = 'current'): int
+    public function count(?string $index = null, string $type = 'current'): int
     {
         return count($index ? Arr::get($this->storage[$type], $index, []) : Arr::flatten($this->storage[$type], 1));
     }
 
-    public function countInHistory(string $index = null): int
+    public function countInHistory(?string $index = null): int
     {
         return $this->count($index, 'history');
     }
@@ -126,7 +126,7 @@ class ArrayStore
             if ($mock = $this->getMock($index, $record['objectID'])) {
                 return $mock;
             }
-            
+
             return $record;
         }, Arr::get($this->storage['current'], $index, []));
     }

--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -34,8 +34,7 @@ class ArrayEngine extends Engine
     /**
      * Update the given model in the index.
      *
-     * @param Collection $models
-     *
+     * @param  Collection  $models
      * @return void
      */
     public function update($models)
@@ -59,8 +58,7 @@ class ArrayEngine extends Engine
     /**
      * Remove the given model from the index.
      *
-     * @param Collection $models
-     *
+     * @param  Collection  $models
      * @return void
      */
     public function delete($models)
@@ -73,7 +71,6 @@ class ArrayEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param Builder $builder
      *
      * @return mixed
      */
@@ -87,7 +84,6 @@ class ArrayEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder  $builder
      * @param  int  $perPage
      * @param  int  $page
      * @return mixed
@@ -103,8 +99,6 @@ class ArrayEngine extends Engine
     /**
      * Perform the given search on the engine.
      *
-     * @param  \Laravel\Scout\Builder  $builder
-     * @param  array  $options
      * @return mixed
      */
     protected function performSearch(Builder $builder, array $options = [])
@@ -114,8 +108,8 @@ class ArrayEngine extends Engine
         $matches = $this->store->find($index, function ($record) use ($builder) {
             $values = new RecursiveIteratorIterator(new RecursiveArrayIterator($record));
 
-            return $this->matchesFilters($record, $builder->wheres) && !empty(array_filter(iterator_to_array($values, false), function ($value) use ($builder) {
-                return !$builder->query || stripos($value, $builder->query) !== false;
+            return $this->matchesFilters($record, $builder->wheres) && ! empty(array_filter(iterator_to_array($values, false), function ($value) use ($builder) {
+                return ! $builder->query || stripos($value, $builder->query) !== false;
             }));
         }, true);
 
@@ -130,8 +124,8 @@ class ArrayEngine extends Engine
     /**
      * Determine if the given record matches given filters.
      *
-     * @param array $record
-     * @param array $filters
+     * @param  array  $record
+     * @param  array  $filters
      * @return bool
      */
     private function matchesFilters($record, $filters)
@@ -148,7 +142,7 @@ class ArrayEngine extends Engine
     /**
      * Pluck and return the primary keys of the given results.
      *
-     * @param mixed $results
+     * @param  mixed  $results
      * @return \Illuminate\Support\Collection
      */
     public function mapIds($results)
@@ -159,9 +153,8 @@ class ArrayEngine extends Engine
     /**
      * Map the given results to instances of the given model.
      *
-     * @param mixed                               $results
-     * @param \Illuminate\Database\Eloquent\Model $model
-     *
+     * @param  mixed  $results
+     * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return Collection
      */
     public function map(Builder $builder, $results, $model)
@@ -184,7 +177,6 @@ class ArrayEngine extends Engine
     /**
      * Map the given results to instances of the given model via a lazy collection.
      *
-     * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
      * @return \Illuminate\Support\LazyCollection
@@ -211,8 +203,7 @@ class ArrayEngine extends Engine
     /**
      * Get the total count from a raw result returned by the engine.
      *
-     * @param mixed $results
-     *
+     * @param  mixed  $results
      * @return int
      */
     public function getTotalCount($results)
@@ -235,7 +226,6 @@ class ArrayEngine extends Engine
      * Create a search index.
      *
      * @param  string  $name
-     * @param  array  $options
      * @return mixed
      */
     public function createIndex($name, array $options = [])
@@ -249,7 +239,6 @@ class ArrayEngine extends Engine
      * @param  string  $name
      * @return mixed
      */
-
     public function deleteIndex($name)
     {
         $this->store->deleteIndex($name);

--- a/src/Fixtures/EmptySearchableModel.php
+++ b/src/Fixtures/EmptySearchableModel.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Sti3bas\ScoutArray\Tests\Fixtures;
+namespace Sti3bas\ScoutArray\Fixtures;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Searchable;
 
-class SearchableModel extends Model
+class EmptySearchableModel extends Model
 {
     use Searchable;
 
@@ -13,11 +13,16 @@ class SearchableModel extends Model
 
     public function searchableAs()
     {
-        return 'test_index';
+        return 'test_index3';
     }
 
     public function getScoutKey()
     {
         return $this->scoutKey;
+    }
+
+    public function toSearchableArray()
+    {
+        return [];
     }
 }

--- a/src/Fixtures/SearchableModel.php
+++ b/src/Fixtures/SearchableModel.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Sti3bas\ScoutArray\Tests\Fixtures;
+namespace Sti3bas\ScoutArray\Fixtures;
 
 use Illuminate\Database\Eloquent\Model;
 use Laravel\Scout\Searchable;
 
-class EmptySearchableModel extends Model
+class SearchableModel extends Model
 {
     use Searchable;
 
@@ -13,16 +13,11 @@ class EmptySearchableModel extends Model
 
     public function searchableAs()
     {
-        return 'test_index3';
+        return 'test_index';
     }
 
     public function getScoutKey()
     {
         return $this->scoutKey;
-    }
-
-    public function toSearchableArray()
-    {
-        return [];
     }
 }

--- a/src/Fixtures/SoftDeletableSearchableModel.php
+++ b/src/Fixtures/SoftDeletableSearchableModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sti3bas\ScoutArray\Tests\Fixtures;
+namespace Sti3bas\ScoutArray\Fixtures;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Search.php
+++ b/src/Search.php
@@ -15,12 +15,12 @@ class Search
         $this->store = $store;
     }
 
-    public function assertContains(Model $model, Closure $callback = null): self
+    public function assertContains(Model $model, ?Closure $callback = null): self
     {
         Assert::assertCount(
             1,
             $this->store->find($model->searchableAs(), function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             }),
             "Failed asserting that model exists in '{$model->searchableAs()}' search index."
         );
@@ -28,11 +28,11 @@ class Search
         return $this;
     }
 
-    public function assertNotContains(Model $model, Closure $callback = null): self
+    public function assertNotContains(Model $model, ?Closure $callback = null): self
     {
         Assert::assertFalse(
             count($this->store->find($model->searchableAs(), function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             })) === 1,
             "Failed asserting that model doesn't exist in '{$model->searchableAs()}' search index."
         );
@@ -40,12 +40,12 @@ class Search
         return $this;
     }
 
-    public function assertContainsIn(string $index, Model $model, Closure $callback = null): self
+    public function assertContainsIn(string $index, Model $model, ?Closure $callback = null): self
     {
         Assert::assertCount(
             1,
             $this->store->find($index, function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             }),
             "Failed asserting that model exists in '{$index}' search index."
         );
@@ -53,11 +53,11 @@ class Search
         return $this;
     }
 
-    public function assertNotContainsIn(string $index, Model $model, Closure $callback = null): self
+    public function assertNotContainsIn(string $index, Model $model, ?Closure $callback = null): self
     {
         Assert::assertFalse(
             count($this->store->find($index, function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             })) === 1,
             "Failed asserting that model doesn't exist in '{$index}' search index."
         );
@@ -67,7 +67,7 @@ class Search
 
     public function assertEmpty(): self
     {
-        Assert::assertEquals(0, $this->store->count(), "Failed asserting that all search indexes are empty.");
+        Assert::assertEquals(0, $this->store->count(), 'Failed asserting that all search indexes are empty.');
 
         return $this;
     }
@@ -82,12 +82,12 @@ class Search
 
         return $this;
     }
-    
+
     public function assertNotEmpty(): self
     {
         Assert::assertTrue(
             $this->store->count() > 0,
-            "Failed asserting that search index is not empty."
+            'Failed asserting that search index is not empty.'
         );
 
         return $this;
@@ -103,11 +103,11 @@ class Search
         return $this;
     }
 
-    public function assertSynced(Model $model, Closure $callback = null): self
+    public function assertSynced(Model $model, ?Closure $callback = null): self
     {
         Assert::assertNotEmpty(
             $this->store->findInHistory($model->searchableAs(), function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             }),
             "Failed asserting that model was synced to '{$model->searchableAs()}' search index."
         );
@@ -115,12 +115,12 @@ class Search
         return $this;
     }
 
-    public function assertNotSynced(Model $model, Closure $callback = null): self
+    public function assertNotSynced(Model $model, ?Closure $callback = null): self
     {
         Assert::assertCount(
             0,
             $this->store->findInHistory($model->searchableAs(), function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             }),
             "Failed asserting that model was not synced to '{$model->searchableAs()}' search index."
         );
@@ -128,11 +128,11 @@ class Search
         return $this;
     }
 
-    public function assertSyncedTo(string $index, Model $model, Closure $callback = null): self
+    public function assertSyncedTo(string $index, Model $model, ?Closure $callback = null): self
     {
         Assert::assertNotEmpty(
             $this->store->findInHistory($index, function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             }),
             "Failed asserting that model was synced to '{$index}' search index."
         );
@@ -140,11 +140,11 @@ class Search
         return $this;
     }
 
-    public function assertNotSyncedTo(string $index, Model $model, Closure $callback = null): self
+    public function assertNotSyncedTo(string $index, Model $model, ?Closure $callback = null): self
     {
         Assert::assertEmpty(
             $this->store->findInHistory($index, function ($record) use ($model, $callback) {
-                return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+                return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
             }),
             "Failed asserting that model was not synced to '{$index}' search index."
         );
@@ -152,10 +152,10 @@ class Search
         return $this;
     }
 
-    public function assertSyncedTimes(Model $model, int $times, Closure $callback = null): self
+    public function assertSyncedTimes(Model $model, int $times, ?Closure $callback = null): self
     {
         $syncedTimes = count($this->store->findInHistory($model->searchableAs(), function ($record) use ($model, $callback) {
-            return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+            return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
         }));
 
         Assert::assertTrue(
@@ -166,10 +166,10 @@ class Search
         return $this;
     }
 
-    public function assertSyncedTimesTo(string $index, Model $model, int $times, Closure $callback = null): self
+    public function assertSyncedTimesTo(string $index, Model $model, int $times, ?Closure $callback = null): self
     {
         $syncedTimes = count($this->store->findInHistory($index, function ($record) use ($model, $callback) {
-            return $record['objectID'] === (string)$model->getScoutKey() && ($callback ? $callback($record) : true);
+            return $record['objectID'] === (string) $model->getScoutKey() && ($callback ? $callback($record) : true);
         }));
 
         Assert::assertTrue(
@@ -185,7 +185,7 @@ class Search
         Assert::assertEquals(
             0,
             $this->store->countInHistory(),
-            "Failed asserting that nothing was synced to search index."
+            'Failed asserting that nothing was synced to search index.'
         );
 
         return $this;
@@ -222,7 +222,7 @@ class Search
         return $this;
     }
 
-    public function fakeRecord(Model $model, array $data, bool $merge = true, string $index = null): self
+    public function fakeRecord(Model $model, array $data, bool $merge = true, ?string $index = null): self
     {
         $this->store->mock($index ?: $model->searchableAs(), $model->getScoutKey(), $data, $merge);
 

--- a/tests/ArrayStoreTest.php
+++ b/tests/ArrayStoreTest.php
@@ -343,7 +343,7 @@ class ArrayStoreTest extends TestCase
         $store->mock('test_index', 'key', [
             'foo' => 'mocked',
         ], false);
-        
+
         $this->assertEquals(['foo' => 'mocked', 'objectID' => 'key'], $store->get('test_index', 'key'));
     }
 
@@ -358,20 +358,20 @@ class ArrayStoreTest extends TestCase
 
         $this->assertTrue($store->indexExists('test'));
     }
-    
+
     /** @test */
     public function it_can_delete_search_index()
     {
         $store = new ArrayStore();
-        
+
         $store->createIndex('test');
         $store->createIndex('test2');
 
         $this->assertTrue($store->indexExists('test'));
         $this->assertTrue($store->indexExists('test2'));
-        
+
         $store->deleteIndex('test');
-        
+
         $this->assertFalse($store->indexExists('test'));
         $this->assertTrue($store->indexExists('test2'));
     }

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -2,16 +2,17 @@
 
 namespace Sti3bas\ScoutArray\Tests\Engines;
 
-use Mockery;
-use Laravel\Scout\Builder;
-use PHPUnit\Framework\TestCase;
 use Illuminate\Support\Collection;
-use Sti3bas\ScoutArray\ArrayStore;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\LazyCollection;
+use Laravel\Scout\Builder;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Sti3bas\ScoutArray\ArrayStore;
 use Sti3bas\ScoutArray\Engines\ArrayEngine;
-use Sti3bas\ScoutArray\Tests\Fixtures\SearchableModel;
 use Sti3bas\ScoutArray\Tests\Fixtures\EmptySearchableModel;
+use Sti3bas\ScoutArray\Tests\Fixtures\SearchableModel;
 use Sti3bas\ScoutArray\Tests\Fixtures\SoftDeletableSearchableModel;
 
 class ArrayEngineTest extends TestCase
@@ -90,7 +91,7 @@ class ArrayEngineTest extends TestCase
         $this->assertCount(2, $results['hits']);
         $this->assertEquals(3, $results['total']);
     }
-   
+
     /** @test */
     public function it_returns_empty_array_if_no_results_found()
     {
@@ -189,7 +190,7 @@ class ArrayEngineTest extends TestCase
 
         $engine = new ArrayEngine(new ArrayStore(), $softDeletesEnabled = false);
         $engine->update(Collection::make([$model, $model2]));
-        
+
         $builder1 = new Builder(new SoftDeletableSearchableModel, '');
         $builder1->wheres = [
             'scoutKey' => 123,
@@ -417,7 +418,7 @@ class ArrayEngineTest extends TestCase
             new SearchableModel(['foo' => 'baz', 'x' => 'x', 'scoutKey' => 2]),
             new SearchableModel(['foo' => 'bar', 'x' => 'z', 'scoutKey' => 3]),
         ]));
-        
+
         $builder = new Builder(new SearchableModel(), null);
         $builder->wheres = [
             'foo' => 'baz',

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -11,9 +11,9 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use Sti3bas\ScoutArray\ArrayStore;
 use Sti3bas\ScoutArray\Engines\ArrayEngine;
-use Sti3bas\ScoutArray\Tests\Fixtures\EmptySearchableModel;
-use Sti3bas\ScoutArray\Tests\Fixtures\SearchableModel;
-use Sti3bas\ScoutArray\Tests\Fixtures\SoftDeletableSearchableModel;
+use Sti3bas\ScoutArray\Fixtures\EmptySearchableModel;
+use Sti3bas\ScoutArray\Fixtures\SearchableModel;
+use Sti3bas\ScoutArray\Fixtures\SoftDeletableSearchableModel;
 
 class ArrayEngineTest extends TestCase
 {

--- a/tests/Fixtures/SoftDeletableSearchableModel.php
+++ b/tests/Fixtures/SoftDeletableSearchableModel.php
@@ -26,7 +26,6 @@ class SoftDeletableSearchableModel extends Model
     /**
      * Prepare a date for array / JSON serialization.
      *
-     * @param  \DateTimeInterface  $date
      * @return string
      */
     protected function serializeDate(DateTimeInterface $date)

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -5,8 +5,8 @@ namespace Sti3bas\ScoutArray\Tests;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Sti3bas\ScoutArray\ArrayStore;
+use Sti3bas\ScoutArray\Fixtures\SearchableModel;
 use Sti3bas\ScoutArray\Search;
-use Sti3bas\ScoutArray\Tests\Fixtures\SearchableModel;
 
 class SearchTest extends TestCase
 {

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -105,7 +105,7 @@ class SearchTest extends TestCase
     public function assert_contains_fails_if_record_does_not_exist()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -136,7 +136,7 @@ class SearchTest extends TestCase
     public function assert_contains_fails_if_callback_returns_false()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -208,7 +208,7 @@ class SearchTest extends TestCase
     public function assert_not_contains_fails_if_callback_returns_true()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -245,7 +245,7 @@ class SearchTest extends TestCase
     public function assert_contains_in_fails_if_record_does_not_exist()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -281,18 +281,18 @@ class SearchTest extends TestCase
     public function assert_contains_in_fails_if_callback_returns_false()
     {
         $this->expectException(AssertionFailedError::class);
-         
+
         $store = new ArrayStore;
         $search = new Search($store);
- 
+
         $model = new SearchableModel(['scoutKey' => 123, 'foo' => 'bar']);
         $model2 = new SearchableModel(['scoutKey' => 234, 'foo' => 'baz']);
- 
+
         $store->set($model->searchableAs(), $model->getScoutKey(), $model->toSearchableArray());
         $store->set('custom_index', $model->getScoutKey(), $model->toSearchableArray());
         $store->set($model2->searchableAs(), $model2->getScoutKey(), $model2->toSearchableArray());
         $store->set('custom_index', $model2->getScoutKey(), $model2->toSearchableArray());
- 
+
         $search->assertContainsIn('custom_index', $model, function ($record) {
             return $record['foo'] === 'baz';
         });
@@ -320,7 +320,7 @@ class SearchTest extends TestCase
     public function assert_not_contains_in_fails_if_record_exists()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -357,18 +357,18 @@ class SearchTest extends TestCase
     public function assert_not_contains_in_fails_if_callback_returns_true()
     {
         $this->expectException(AssertionFailedError::class);
-         
+
         $store = new ArrayStore;
         $search = new Search($store);
- 
+
         $model = new SearchableModel(['scoutKey' => 123, 'foo' => 'baz']);
         $model2 = new SearchableModel(['scoutKey' => 234, 'foo' => 'baz']);
- 
+
         $store->set($model->searchableAs(), $model->getScoutKey(), $model->toSearchableArray());
         $store->set('custom_index', $model->getScoutKey(), $model->toSearchableArray());
         $store->set($model2->searchableAs(), $model2->getScoutKey(), $model2->toSearchableArray());
         $store->set('custom_index', $model2->getScoutKey(), $model2->toSearchableArray());
- 
+
         $search->assertNotContainsIn('custom_index', $model, function ($record) {
             return $record['foo'] === 'baz';
         });
@@ -379,7 +379,7 @@ class SearchTest extends TestCase
     {
         $store = new ArrayStore;
         $search = new Search($store);
- 
+
         $result = $search->assertEmpty();
 
         $this->assertInstanceOf(Search::class, $result);
@@ -394,10 +394,10 @@ class SearchTest extends TestCase
         $search = new Search($store);
 
         $store->set('test', 'test', ['foo' => 'bar']);
- 
+
         $search->assertEmpty();
     }
-    
+
     /** @test */
     public function assert_empty_in_passes_if_no_records_exists()
     {
@@ -405,7 +405,7 @@ class SearchTest extends TestCase
         $search = new Search($store);
 
         $store->set('test', 'test', ['foo' => 'bar']);
- 
+
         $result = $search->assertEmptyIn('test2');
 
         $this->assertInstanceOf(Search::class, $result);
@@ -420,7 +420,7 @@ class SearchTest extends TestCase
         $search = new Search($store);
 
         $store->set('test', 'test', ['foo' => 'bar']);
- 
+
         $search->assertEmptyIn('test');
     }
 
@@ -433,7 +433,7 @@ class SearchTest extends TestCase
         $store->set('test', 'test', [
             'foo' => 'bar',
         ]);
- 
+
         $result = $search->assertNotEmpty();
 
         $this->assertInstanceOf(Search::class, $result);
@@ -459,7 +459,7 @@ class SearchTest extends TestCase
         $store->set('test', 'test', [
             'foo' => 'bar',
         ]);
- 
+
         $result = $search->assertNotEmptyIn('test');
 
         $this->assertInstanceOf(Search::class, $result);
@@ -476,7 +476,7 @@ class SearchTest extends TestCase
         $store->set('test2', 'test', [
             'foo' => 'bar',
         ]);
- 
+
         $search->assertNotEmptyIn('test');
     }
 
@@ -504,7 +504,7 @@ class SearchTest extends TestCase
     public function assert_synced_fails_if_no_records_exists_in_history()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -530,7 +530,7 @@ class SearchTest extends TestCase
         $store->set($model->searchableAs(), $model->getScoutKey(), $model->toSearchableArray());
         $store->set($model2->searchableAs(), $model2->getScoutKey(), $model2->toSearchableArray());
         $store->set($model3->searchableAs(), $model3->getScoutKey(), $model3->toSearchableArray());
-        
+
         $store->forget($model->searchableAs(), $model->getScoutKey());
 
         $search->assertSynced($model, function ($record) {
@@ -546,7 +546,7 @@ class SearchTest extends TestCase
     public function assert_synced_fails_if_callback_returns_false_and_records_exists_in_history()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -604,7 +604,7 @@ class SearchTest extends TestCase
     public function assert_not_synced_fails_if_record_exists_in_history()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -613,7 +613,7 @@ class SearchTest extends TestCase
 
         $store->set($model->searchableAs(), $model->getScoutKey(), $model->toSearchableArray());
         $store->set($model2->searchableAs(), $model2->getScoutKey(), $model2->toSearchableArray());
-        
+
         $store->forget($model->searchableAs(), $model->getScoutKey());
 
         $search->assertNotSynced($model);
@@ -633,7 +633,7 @@ class SearchTest extends TestCase
         $store->set('custom_index', $model->getScoutKey(), $model->toSearchableArray());
         $store->set($model2->searchableAs(), $model2->getScoutKey(), $model2->toSearchableArray());
         $store->set($model3->searchableAs(), $model3->getScoutKey(), $model3->toSearchableArray());
-        
+
         $store->forget($model->searchableAs(), $model->getScoutKey());
 
         $search->assertNotSynced($model, function ($record) {
@@ -649,7 +649,7 @@ class SearchTest extends TestCase
     public function assert_not_synced_fails_if_callback_returns_true_and_records_exists_in_history()
     {
         $this->expectException(AssertionFailedError::class);
-        
+
         $store = new ArrayStore;
         $search = new Search($store);
 
@@ -788,7 +788,7 @@ class SearchTest extends TestCase
 
         $this->assertInstanceOf(Search::class, $result);
     }
-    
+
     /** @test */
     public function assert_not_synced_to_fails_if_record_exists_in_history()
     {
@@ -808,7 +808,7 @@ class SearchTest extends TestCase
 
         $search->assertNotSyncedTo('custom_index', $model);
     }
-    
+
     /** @test */
     public function assert_not_synced_to_passes_if_callback_returns_false_and_records_exists_in_history()
     {
@@ -1158,7 +1158,7 @@ class SearchTest extends TestCase
 
         $search->assertNothingSynced();
     }
-    
+
     /** @test */
     public function assert_nothing_synced_to_passes_if_no_records_exists()
     {


### PR DESCRIPTION
This PR introduces support for Laravel 11, drops support for Laravel 9 and PHP 8.0. I've also updated Github Actions workflow to test against Laravel 10 and 11 on PHP 8.1, 8.2 and 8.3.

Linted with [Laravel Pint](https://laravel.com/docs/10.x/pint).

Please note I moved the Fixtures to be within `src/Fixtures` as I ran into PHPUnit failing the tests due to it throwing `Class EmptySearchableModel cannot be found in laravel-scout-array-driver/tests/Fixtures/EmptySearchableModel.php`