### PR TITLE
Add an ability to fake search response data

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -25,10 +25,16 @@ class ArrayEngine extends Engine
      */
     protected $softDelete;
 
+    /**
+     * @var Collection
+     */
+    protected $searchResponseMocks;
+
     public function __construct($store, $softDelete = false)
     {
         $this->store = $store;
         $this->softDelete = $softDelete;
+        $this->searchResponseMocks = collect();
     }
 
     /**
@@ -118,10 +124,16 @@ class ArrayEngine extends Engine
 
         $matches = Collection::make($matches);
 
-        return [
+        $searchResponseMock = $this->searchResponseMocks->first(function ($mock) use ($builder, $index) {
+            return $mock->matches($builder) && (($mock->fakeBuilder->index == '*') || ($index == $mock->fakeBuilder->index));
+        });
+
+        $response = [
             'hits' => (isset($options['perPage']) ? $matches->slice((($options['page'] ?? 1) - 1) * $options['perPage'], $options['perPage']) : $matches)->values()->all(),
             'total' => $matches->count(),
         ];
+
+        return $searchResponseMock ? $searchResponseMock->toArray($response) : $response;
     }
 
     /**
@@ -291,5 +303,10 @@ class ArrayEngine extends Engine
         return $this->constrainForSoftDeletes(
             $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
         );
+    }
+
+    public function addSearchResponseMock($mock)
+    {
+        $this->searchResponseMocks->add($mock);
     }
 }

--- a/src/FakeBuilder.php
+++ b/src/FakeBuilder.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Sti3bas\ScoutArray;
+
+class FakeBuilder
+{
+    public $index = '*';
+
+    public $wheres = [];
+
+    public $whereIns = [];
+
+    public $whereNotIns = [];
+
+    public $limit;
+
+    public $orders = [];
+
+    public $options = [];
+
+    public $query;
+
+    public function within($index)
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
+    public function where($field, $value)
+    {
+        $this->wheres[$field] = $value;
+
+        return $this;
+    }
+
+    public function whereIn($field, array $values)
+    {
+        $this->whereIns[$field] = $values;
+
+        return $this;
+    }
+
+    public function whereNotIn($field, array $values)
+    {
+        $this->whereNotIns[$field] = $values;
+
+        return $this;
+    }
+
+    public function withTrashed()
+    {
+        unset($this->wheres['__soft_deleted']);
+
+        return $this;
+    }
+
+    public function onlyTrashed()
+    {
+        return tap($this->withTrashed(), function () {
+            $this->wheres['__soft_deleted'] = 1;
+        });
+    }
+
+    public function take($limit)
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function orderBy($column, $direction = 'asc')
+    {
+        $this->orders[] = [
+            'column' => $column,
+            'direction' => strtolower($direction) == 'asc' ? 'asc' : 'desc',
+        ];
+
+        return $this;
+    }
+
+    public function latest($column = 'created_at')
+    {
+        return $this->orderBy($column, 'desc');
+    }
+
+    public function oldest($column = 'created_at')
+    {
+        return $this->orderBy($column, 'asc');
+    }
+
+    public function options(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function query($query)
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+}

--- a/src/ScoutArrayEngineServiceProvider.php
+++ b/src/ScoutArrayEngineServiceProvider.php
@@ -20,11 +20,11 @@ class ScoutArrayEngineServiceProvider extends ServiceProvider
         });
 
         $this->app[EngineManager::class]->extend('array', function ($app) {
-            return new ArrayEngine($this->app[ArrayStore::class], config('scout.soft_delete'));
+            return new ArrayEngine($app[ArrayStore::class], config('scout.soft_delete'));
         });
 
         $this->app->bind(Search::class, function () {
-            return new Search($this->app[ArrayStore::class]);
+            return new Search($this->app[EngineManager::class]->engine('array'));
         });
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -5,14 +5,18 @@ namespace Sti3bas\ScoutArray;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Assert;
+use Sti3bas\ScoutArray\Engines\ArrayEngine;
 
 class Search
 {
-    protected $store;
+    protected ArrayStore $store;
 
-    public function __construct(ArrayStore $store)
+    protected ArrayEngine $engine;
+
+    public function __construct(ArrayEngine $engine)
     {
-        $this->store = $store;
+        $this->store = $engine->store;
+        $this->engine = $engine;
     }
 
     public function assertContains(Model $model, ?Closure $callback = null): self
@@ -253,5 +257,16 @@ class Search
         $this->store->mock($index ?: $model->searchableAs(), $model->getScoutKey(), $data, $merge);
 
         return $this;
+    }
+
+    public function fakeResponseData(array $data)
+    {
+        $fakeBuilder = new FakeBuilder();
+
+        $searchResponseMock = new SearchResponseMock($fakeBuilder, $data);
+
+        $this->engine->addSearchResponseMock($searchResponseMock);
+
+        return $fakeBuilder;
     }
 }

--- a/src/SearchResponseMock.php
+++ b/src/SearchResponseMock.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sti3bas\ScoutArray;
+
+use Laravel\Scout\Builder;
+
+class SearchResponseMock
+{
+    public FakeBuilder $fakeBuilder;
+
+    public array $mockData;
+
+    public function __construct(FakeBuilder $fakeBuilder, array $mockData)
+    {
+        $this->fakeBuilder = $fakeBuilder;
+        $this->mockData = $mockData;
+    }
+
+    public function matches(Builder $builder)
+    {
+        return $builder->wheres == $this->fakeBuilder->wheres &&
+            $builder->whereIns == $this->fakeBuilder->whereIns &&
+            $builder->whereNotIns == $this->fakeBuilder->whereNotIns &&
+            $builder->limit == $this->fakeBuilder->limit &&
+            $builder->orders == $this->fakeBuilder->orders &&
+            $builder->options == $this->fakeBuilder->options &&
+            $builder->query == $this->fakeBuilder->query;
+    }
+
+    public function toArray(array $data): array
+    {
+        return array_merge($data, $this->mockData);
+    }
+}


### PR DESCRIPTION
It is still work in progress and there might be API changes.

Usage:

```php
Search::fakeResponseData([
   'foo' => 'bar'
])->query('test');

$search = User::search('test')->raw();

$this->assertEquals('bar', $search['bar']);
```

It is possible to provide filters (supports all Laravel\Scout\Builder methods) to fake response data for a specific search:
```php
Search::fakeResponseData([
   'foo' => 'bar'
])
   ->within('users')
   ->where('foo', 'bar'),
   ->whereIn('foo', ['bar', 'baz'])
   ->whereNotIn('foo', ['foo', 'bar'])
   ->withTrashed()
   ->onlyTrashed()
   ->take(50)
   ->orderBy('test', 'desc')
   ->latest('created_at')
   ->oldest('updated_at')
   ->options(['foo' => 'bar']);
```

TODO:
- provide a way to specify global fake response data without having to specify filters