### PR TITLE
[Bugfix] Handle array or collection comparison in filter matching

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -140,7 +140,19 @@ class ArrayEngine extends Engine
 
         $match = function ($record, $key, $value) {
             if (is_array($value)) {
-                return in_array(data_get($record, $key), $value, true);
+                $needle = data_get($record, $key);
+
+                if (is_array($needle)) {
+                    return !empty(array_intersect($needle, $value));
+                }
+
+                if ($needle instanceof Collection) {
+                    return $needle->contains(function ($item) use ($value) {
+                        return in_array($item, $value, true);
+                    });
+                }
+
+                return in_array($needle, $value, true);
             }
             return data_get($record, $key) === $value;
         };

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -457,6 +457,46 @@ class ArrayEngineTest extends TestCase
     }
 
     /** @test */
+    public function it_can_be_filtered_using_where_in_array()
+    {
+        $engine = new ArrayEngine(new ArrayStore());
+        $engine->update(Collection::make([
+            new SearchableModel(['foo' => 'bar', 'x' => ['x', 'y'], 'scoutKey' => 1]),
+            new SearchableModel(['foo' => 'baz', 'x' => ['x'], 'scoutKey' => 2]),
+            new SearchableModel(['foo' => 'bax', 'x' => ['z'], 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel(), null);
+        $builder->whereIns = [
+            'x' => ['x', 'y']
+        ];
+        $results = $engine->search($builder);
+
+        $this->assertCount(2, $results['hits']);
+        $this->assertEquals([2, 1], array_column($results['hits'], 'scoutKey'));
+    }
+
+    /** @test */
+    public function it_can_be_filtered_using_where_in_collection()
+    {
+        $engine = new ArrayEngine(new ArrayStore());
+        $engine->update(Collection::make([
+            new SearchableModel(['foo' => 'bar', 'x' => collect(['x', 'y']), 'scoutKey' => 1]),
+            new SearchableModel(['foo' => 'baz', 'x' => collect(['x']), 'scoutKey' => 2]),
+            new SearchableModel(['foo' => 'bax', 'x' => collect(['z']), 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel(), null);
+        $builder->whereIns = [
+            'x' => ['x', 'y']
+        ];
+        $results = $engine->search($builder);
+
+        $this->assertCount(2, $results['hits']);
+        $this->assertEquals([2, 1], array_column($results['hits'], 'scoutKey'));
+    }
+
+    /** @test */
     public function it_can_be_filtered_using_where_not_in()
     {
         $engine = new ArrayEngine(new ArrayStore());


### PR DESCRIPTION
## Allow where in using an array or a collection

For situations that have HasMany relationship or BelongToMany, such as a `User` that has many roles, and it is necessary to search for users by the role name, the searchableArray method is defined like this:
```php
public function toSearchableArray(): array
{
    return [
     ...
        ‘roles’ => $this->roles->pluck(‘name’),
     ...
    ];
}
```
or

```php
public function toSearchableArray(): array
{
   return [
   ...
       ‘roles’ => $this->roles->pluck(‘name’)->toArray(),
   ...
   ];
}
```

has the same goal as #26, but including collection comparison