### PR TITLE
Add support for Laravel Scout 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^8.0",
-       "illuminate/bus": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/bus": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/database": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/pagination": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/queue": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
-        "laravel/scout": "^10.0"
+        "laravel/scout": "^10.0|^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
## Summary
- Add Laravel Scout v11 to the package composer constraints
- Keep existing Laravel Scout v10 support intact

## Test plan
- [x] Run package test suite locally (`vendor/bin/phpunit`)