### PR TITLE
Fix Scout 11 where filter compatibility

### DIFF
--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -139,6 +139,28 @@ class ArrayEngine extends Engine
         }
 
         $match = function ($record, $key, $value) {
+            if (is_array($key) && array_key_exists('field', $key)) {
+                $field = $key['field'] ?? null;
+                $operator = $key['operator'] ?? '=';
+                $value = $key['value'] ?? null;
+
+                if (! is_string($field)) {
+                    return false;
+                }
+
+                $actual = data_get($record, $field);
+
+                return match ($operator) {
+                    '=', '==' => $actual === $value,
+                    '!=' => $actual !== $value,
+                    '<' => $actual < $value,
+                    '>' => $actual > $value,
+                    '<=' => $actual <= $value,
+                    '>=' => $actual >= $value,
+                    default => $actual === $value,
+                };
+            }
+
             if (is_array($value)) {
                 $needle = data_get($record, $key);
 
@@ -159,6 +181,10 @@ class ArrayEngine extends Engine
         };
 
         $match = Collection::make($filters)->every(function ($value, $key) use ($match, $record) {
+            if (is_array($value) && array_key_exists('field', $value)) {
+                return $match($record, $value, null);
+            }
+
             $keyExploded = explode('.', $key);
             if (count($keyExploded) > 1) {
                 if (data_get($record, $keyExploded[0]) instanceof Collection) {

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -415,6 +415,25 @@ class ArrayEngineTest extends TestCase
         $this->assertEquals(2, $results['hits'][0]['scoutKey']);
     }
 
+    public function test_it_can_be_filtered_using_builder_where_method()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['foo' => 'bar', 'x' => 'y', 'scoutKey' => 1]),
+            new SearchableModel(['foo' => 'baz', 'x' => 'x', 'scoutKey' => 2]),
+            new SearchableModel(['foo' => 'bar', 'x' => 'z', 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('foo', 'baz');
+        $builder->where('x', 'x');
+
+        $results = $engine->search($builder);
+
+        $this->assertCount(1, $results['hits']);
+        $this->assertEquals(2, $results['hits'][0]['scoutKey']);
+    }
+
     public function test_it_can_be_filtered_using_where_in()
     {
         $engine = new ArrayEngine(new ArrayStore);


### PR DESCRIPTION
## Summary

This fixes Scout 11 compatibility for `search()->where(...)` in the array driver.

Scout 10 and Scout 11 build `Builder::$wheres` differently:

- Scout 10 stores filters in the older associative `field => value` format
- Scout 11 stores them as structured entries with `field` / `operator` / `value`

`ArrayEngine::matchesFilters()` still assumed the older format, which caused filtered searches to return no results under Scout 11.

This PR updates the runtime filter handling and adds a test that exercises the public `Builder::where(...)` API instead of manually assigning the old internal `$builder->wheres` structure.

For additional context, I summarized the original compatibility gap on the earlier Scout 11 support PR:
https://github.com/Sti3bas/laravel-scout-array-driver/pull/31#issuecomment-4189088272

## Question

Would you be open to gradually moving more filter-related tests to Scout's public API (`where()`, `whereIn()`, `whereNotIn()`) instead of manually assigning internal builder arrays `$builder->wheres = [...]`?

I noticed several tests currently set `$builder->wheres` directly. That is fine for narrow engine-level tests, but it also means framework-level changes in Scout internals can slip through without failing the suite, which is what happened here.
