### PR TITLE
Fix ArrayEngine compatibility with Scout 11's where/orderBy builder format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "illuminate/pagination": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/queue": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
-        "laravel/scout": "^10.0|^11.0"
+        "laravel/scout": "^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -205,7 +205,7 @@ class ArrayEngine extends Engine
                 $current = $current->all();
             }
 
-            if (is_array($current) && array_is_list($current)) {
+            if (is_array($current) && $this->isListArray($current)) {
                 $remaining = implode('.', array_slice($segments, $i));
 
                 return Collection::make($current)->map(fn ($item) => data_get($item, $remaining))->flatten()->all();
@@ -223,6 +223,18 @@ class ArrayEngine extends Engine
         }
 
         return $current;
+    }
+
+    /**
+     * Determine if the given array is a list (PHP 8.0–compatible array_is_list).
+     */
+    private function isListArray(array $array): bool
+    {
+        if ($array === []) {
+            return true;
+        }
+
+        return array_keys($array) === range(0, count($array) - 1);
     }
 
     /**

--- a/src/Engines/ArrayEngine.php
+++ b/src/Engines/ArrayEngine.php
@@ -2,6 +2,7 @@
 
 namespace Sti3bas\ScoutArray\Engines;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
@@ -35,22 +36,22 @@ class ArrayEngine extends Engine
      * Update the given model in the index.
      *
      * @param  Collection  $models
-     * @return void
      */
-    public function update($models)
+    public function update($models): void
     {
         if ($this->usesSoftDelete($models->first()) && $this->softDelete) {
             $models->each->pushSoftDeleteMetadata();
         }
 
-        $models->each(function ($model) {
+        $models->each(function ($model): void {
             if (empty($searchableData = $model->toSearchableArray())) {
                 return;
             }
 
             $this->store->set($model->searchableAs(), $model->getScoutKey(), array_merge(
                 $searchableData,
-                $model->scoutMetadata()
+                $model->scoutMetadata(),
+                [$model->getScoutKeyName() => $model->getScoutKey()]
             ));
         });
     }
@@ -108,15 +109,27 @@ class ArrayEngine extends Engine
         $matches = $this->store->find($index, function ($record) use ($builder) {
             $values = new RecursiveIteratorIterator(new RecursiveArrayIterator($record));
 
-            return $this->matchesFilters($record, $builder->wheres) &&
-                $this->matchesFilters($record, $builder->whereIns) &&
-                $this->matchesFilters($record, data_get($builder, 'whereNotIns', []), true) &&
-                ! empty(array_filter(iterator_to_array($values, false), function ($value) use ($builder) {
-                    return ! $builder->query || stripos($value, $builder->query) !== false;
-                }));
+            return $this->matchesWheres($record, $builder->wheres)
+                && $this->matchesKeyValueFilters($record, $builder->whereIns)
+                && $this->matchesKeyValueFilters($record, $builder->whereNotIns, true)
+                && ! empty(array_filter(iterator_to_array($values, false), fn ($value) => ! $builder->query || stripos($value, $builder->query) !== false));
         }, true);
 
         $matches = Collection::make($matches);
+
+        if (! empty($builder->orders)) {
+            $matches = $matches->sort(function ($a, $b) use ($builder) {
+                foreach ($builder->orders as $order) {
+                    $comparison = data_get($a, $order['column']) <=> data_get($b, $order['column']);
+
+                    if ($comparison !== 0) {
+                        return $order['direction'] === 'desc' ? -$comparison : $comparison;
+                    }
+                }
+
+                return 0;
+            })->values();
+        }
 
         return [
             'hits' => (isset($options['perPage']) ? $matches->slice((($options['page'] ?? 1) - 1) * $options['perPage'], $options['perPage']) : $matches)->values()->all(),
@@ -127,60 +140,96 @@ class ArrayEngine extends Engine
     /**
      * Determine if the given record matches given filters.
      *
-     * @param  array  $record
      * @param  array  $filters
      * @param  bool  $not
-     * @return bool
      */
-    private function matchesFilters($record, $filters, $not = false)
+    private function matchesWheres(array $record, array $wheres): bool
+    {
+        foreach ($wheres as $where) {
+            $value = data_get($record, $where['field']);
+
+            $matches = match ($where['operator']) {
+                '=' => $value === $where['value'],
+                '!=' => $value !== $where['value'],
+                '>' => $value > $where['value'],
+                '>=' => $value >= $where['value'],
+                '<' => $value < $where['value'],
+                '<=' => $value <= $where['value'],
+                default => $value === $where['value'],
+            };
+
+            if (! $matches) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function matchesKeyValueFilters(array $record, array $filters, bool $not = false): bool
     {
         if (empty($filters)) {
             return true;
         }
 
-        $match = function ($record, $key, $value) {
-            if (is_array($value)) {
-                $needle = data_get($record, $key);
+        $match = Collection::make($filters)->every(function ($value, $key) use ($record) {
+            $needle = $this->resolveDottedValue($record, $key);
 
-                if (is_array($needle)) {
-                    return ! empty(array_intersect($needle, $value));
-                }
-
-                if ($needle instanceof Collection) {
-                    return $needle->contains(function ($item) use ($value) {
-                        return in_array($item, $value, true);
-                    });
-                }
-
-                return in_array($needle, $value, true);
+            if (is_array($needle)) {
+                return ! empty(array_intersect($needle, $value));
             }
 
-            return data_get($record, $key) === $value;
-        };
-
-        $match = Collection::make($filters)->every(function ($value, $key) use ($match, $record) {
-            $keyExploded = explode('.', $key);
-            if (count($keyExploded) > 1) {
-                if (data_get($record, $keyExploded[0]) instanceof Collection) {
-                    return data_get($record, $keyExploded[0])->contains(function ($subRecord) use ($match, $keyExploded, $value) {
-                        return $match($subRecord, $keyExploded[1], $value);
-                    });
-                }
-
-                return $match($record, $keyExploded, $value);
-            }
-
-            return $match($record, $key, $value);
+            return in_array($needle, $value, true);
         });
 
         return $not ? ! $match : $match;
+    }
+
+    private function resolveDottedValue(array $record, string $key)
+    {
+        $direct = data_get($record, $key);
+
+        if ($direct instanceof Collection) {
+            $direct = $direct->all();
+        }
+
+        if ($direct !== null) {
+            return $direct;
+        }
+
+        $segments = explode('.', $key);
+        $current = $record;
+
+        foreach ($segments as $i => $segment) {
+            if ($current instanceof Collection) {
+                $current = $current->all();
+            }
+
+            if (is_array($current) && array_is_list($current)) {
+                $remaining = implode('.', array_slice($segments, $i));
+
+                return Collection::make($current)->map(fn ($item) => data_get($item, $remaining))->flatten()->all();
+            }
+
+            $current = data_get($current, $segment);
+
+            if ($current === null) {
+                return null;
+            }
+        }
+
+        if ($current instanceof Collection) {
+            $current = $current->all();
+        }
+
+        return $current;
     }
 
     /**
      * Pluck and return the primary keys of the given results.
      *
      * @param  mixed  $results
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function mapIds($results)
     {
@@ -191,7 +240,7 @@ class ArrayEngine extends Engine
      * Map the given results to instances of the given model.
      *
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return Collection
      */
     public function map(Builder $builder, $results, $model)
@@ -215,8 +264,8 @@ class ArrayEngine extends Engine
      * Map the given results to instances of the given model via a lazy collection.
      *
      * @param  mixed  $results
-     * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return \Illuminate\Support\LazyCollection
+     * @param  Model  $model
+     * @return LazyCollection
      */
     public function lazyMap(Builder $builder, $results, $model)
     {
@@ -251,7 +300,7 @@ class ArrayEngine extends Engine
     /**
      * Flush all of the model's records from the engine.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return void
      */
     public function flush($model)
@@ -284,7 +333,7 @@ class ArrayEngine extends Engine
     /**
      * Determine if the given model uses soft deletes.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return bool
      */
     protected function usesSoftDelete($model)
@@ -302,7 +351,8 @@ class ArrayEngine extends Engine
         );
 
         return $this->constrainForSoftDeletes(
-            $builder, $this->addAdditionalConstraints($builder, $query->take($builder->limit))
+            $builder,
+            $this->addAdditionalConstraints($builder, $query->take($builder->limit))
         );
     }
 }

--- a/tests/Engines/ArrayEngineTest.php
+++ b/tests/Engines/ArrayEngineTest.php
@@ -29,10 +29,10 @@ class ArrayEngineTest extends TestCase
     protected function tearDown(): void
     {
         $this->addToAssertionCount(
-            \Mockery::getContainer()->mockery_getExpectationCount()
+            Mockery::getContainer()->mockery_getExpectationCount()
         );
 
-        \Mockery::close();
+        Mockery::close();
 
         parent::tearDown();
     }
@@ -141,17 +141,15 @@ class ArrayEngineTest extends TestCase
         $engine->update(Collection::make([$model]));
 
         $builder = new Builder(new SearchableModel, '');
-        $builder->wheres = [
-            'id' => 123,
-        ];
+        $builder->where('scoutKey', 'test');
 
-        $this->assertEquals(['id' => 123, 'foo' => 'bar', 'objectID' => 'test', 'meta' => 'test', 'scoutKey' => 'test'], $engine->search($builder)['hits'][0]);
+        $this->assertEquals(['id' => 'test', 'foo' => 'bar', 'objectID' => 'test', 'meta' => 'test', 'scoutKey' => 'test'], $engine->search($builder)['hits'][0]);
 
         $model->foo = 'baz';
 
         $engine->update(Collection::make([$model]));
 
-        $this->assertEquals(['id' => 123, 'foo' => 'baz', 'objectID' => 'test', 'meta' => 'test', 'scoutKey' => 'test'], $engine->search($builder)['hits'][0]);
+        $this->assertEquals(['id' => 'test', 'foo' => 'baz', 'objectID' => 'test', 'meta' => 'test', 'scoutKey' => 'test'], $engine->search($builder)['hits'][0]);
     }
 
     public function test_it_can_update_soft_deletable_records_in_the_index()
@@ -165,17 +163,13 @@ class ArrayEngineTest extends TestCase
         $engine->update(Collection::make([$model, $model2]));
 
         $builder1 = new Builder(new SoftDeletableSearchableModel, '');
-        $builder1->wheres = [
-            'scoutKey' => 123,
-        ];
+        $builder1->where('scoutKey', 123);
 
         $builder2 = new Builder(new SoftDeletableSearchableModel, '');
-        $builder2->wheres = [
-            'scoutKey' => 234,
-        ];
+        $builder2->where('scoutKey', 234);
 
-        $this->assertEquals(['foo' => 'bar', 'objectID' => '123', 'scoutKey' => 123, 'deleted_at' => '2019-01-01 12:00:00', '__soft_deleted' => 1], $engine->search($builder1)['hits'][0]);
-        $this->assertEquals(['foo' => 'bar', 'objectID' => '234', 'scoutKey' => 234, '__soft_deleted' => 0], $engine->search($builder2)['hits'][0]);
+        $this->assertEquals(['foo' => 'bar', 'objectID' => '123', 'scoutKey' => 123, 'id' => 123, 'deleted_at' => '2019-01-01 12:00:00', '__soft_deleted' => 1], $engine->search($builder1)['hits'][0]);
+        $this->assertEquals(['foo' => 'bar', 'objectID' => '234', 'scoutKey' => 234, 'id' => 234, '__soft_deleted' => 0], $engine->search($builder2)['hits'][0]);
     }
 
     public function test_it_will_not_push_soft_delete_metadata_when_updating_if_its_not_enabled()
@@ -189,17 +183,13 @@ class ArrayEngineTest extends TestCase
         $engine->update(Collection::make([$model, $model2]));
 
         $builder1 = new Builder(new SoftDeletableSearchableModel, '');
-        $builder1->wheres = [
-            'scoutKey' => 123,
-        ];
+        $builder1->where('scoutKey', 123);
 
         $builder2 = new Builder(new SoftDeletableSearchableModel, '');
-        $builder2->wheres = [
-            'scoutKey' => 234,
-        ];
+        $builder2->where('scoutKey', 234);
 
-        $this->assertEquals(['foo' => 'bar', 'objectID' => '123', 'scoutKey' => 123, 'deleted_at' => '2019-01-01 12:00:00'], $engine->search($builder1)['hits'][0]);
-        $this->assertEquals(['foo' => 'bar', 'objectID' => '234', 'scoutKey' => 234], $engine->search($builder2)['hits'][0]);
+        $this->assertEquals(['foo' => 'bar', 'objectID' => '123', 'scoutKey' => 123, 'id' => 123, 'deleted_at' => '2019-01-01 12:00:00'], $engine->search($builder1)['hits'][0]);
+        $this->assertEquals(['foo' => 'bar', 'objectID' => '234', 'scoutKey' => 234, 'id' => 234], $engine->search($builder2)['hits'][0]);
     }
 
     public function test_it_will_not_update_empty_records_in_the_index()
@@ -210,9 +200,7 @@ class ArrayEngineTest extends TestCase
         $engine->update(Collection::make([$model]));
 
         $builder = new Builder(new EmptySearchableModel, '');
-        $builder->wheres = [
-            'scoutKey' => 123,
-        ];
+        $builder->where('scoutKey', 123);
 
         $this->assertEmpty($engine->search($builder)['hits']);
     }
@@ -227,9 +215,7 @@ class ArrayEngineTest extends TestCase
         $engine->update(Collection::make([$model1, $model2, $model3]));
 
         $builder = new Builder(new SearchableModel, '');
-        $builder->wheres = [
-            'scoutKey' => 2,
-        ];
+        $builder->where('scoutKey', 2);
 
         $this->assertCount(1, $engine->search($builder)['hits']);
 
@@ -270,9 +256,7 @@ class ArrayEngineTest extends TestCase
         ]));
 
         $builder = new Builder(new SearchableModel, 'bar');
-        $builder->wheres = [
-            'foo' => 'bar',
-        ];
+        $builder->where('foo', 'bar');
 
         $results = $engine->paginate($builder, 2, 1);
 
@@ -384,9 +368,7 @@ class ArrayEngineTest extends TestCase
         ]));
 
         $builder = new Builder(new SearchableModel, '');
-        $builder->wheres = [
-            'foo' => 'bar',
-        ];
+        $builder->where('foo', 'bar');
 
         $this->assertCount(3, $engine->search($builder)['hits']);
 
@@ -405,14 +387,112 @@ class ArrayEngineTest extends TestCase
         ]));
 
         $builder = new Builder(new SearchableModel, null);
-        $builder->wheres = [
-            'foo' => 'baz',
-            'x' => 'x',
-        ];
+        $builder->where('foo', 'baz');
+        $builder->where('x', 'x');
         $results = $engine->search($builder);
 
         $this->assertCount(1, $results['hits']);
         $this->assertEquals(2, $results['hits'][0]['scoutKey']);
+    }
+
+    public function test_it_can_be_filtered_using_where_with_explicit_equals_operator()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 1]),
+            new SearchableModel(['foo' => 'baz', 'scoutKey' => 2]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('foo', '=', 'baz');
+        $results = $engine->search($builder);
+
+        $this->assertCount(1, $results['hits']);
+        $this->assertEquals(2, $results['hits'][0]['scoutKey']);
+    }
+
+    public function test_it_can_be_filtered_using_where_with_not_equals_operator()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['foo' => 'bar', 'scoutKey' => 1]),
+            new SearchableModel(['foo' => 'baz', 'scoutKey' => 2]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('foo', '!=', 'baz');
+        $results = $engine->search($builder);
+
+        $this->assertCount(1, $results['hits']);
+        $this->assertEquals(1, $results['hits'][0]['scoutKey']);
+    }
+
+    public function test_it_can_be_filtered_using_where_with_greater_than_operator()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 10, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 30, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('price', '>', 20);
+        $results = $engine->search($builder);
+
+        $this->assertCount(1, $results['hits']);
+        $this->assertEquals(3, $results['hits'][0]['scoutKey']);
+    }
+
+    public function test_it_can_be_filtered_using_where_with_greater_than_or_equal_operator()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 10, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 30, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('price', '>=', 20);
+        $results = $engine->search($builder);
+
+        $this->assertCount(2, $results['hits']);
+        $this->assertEquals([3, 2], array_column($results['hits'], 'scoutKey'));
+    }
+
+    public function test_it_can_be_filtered_using_where_with_less_than_operator()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 10, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 30, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('price', '<', 20);
+        $results = $engine->search($builder);
+
+        $this->assertCount(1, $results['hits']);
+        $this->assertEquals(1, $results['hits'][0]['scoutKey']);
+    }
+
+    public function test_it_can_be_filtered_using_where_with_less_than_or_equal_operator()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 10, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 30, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->where('price', '<=', 20);
+        $results = $engine->search($builder);
+
+        $this->assertCount(2, $results['hits']);
+        $this->assertEquals([2, 1], array_column($results['hits'], 'scoutKey'));
     }
 
     public function test_it_can_be_filtered_using_where_in()
@@ -492,6 +572,85 @@ class ArrayEngineTest extends TestCase
         $this->assertCount(2, $results['hits']);
         $this->assertEquals(3, $results['hits'][0]['scoutKey']);
         $this->assertEquals(1, $results['hits'][1]['scoutKey']);
+    }
+
+    public function test_it_can_order_results_ascending()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 30, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 10, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->orderBy('price', 'asc');
+        $results = $engine->search($builder);
+
+        $this->assertEquals([2, 3, 1], array_column($results['hits'], 'scoutKey'));
+    }
+
+    public function test_it_can_order_results_descending()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 30, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 10, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->orderBy('price', 'desc');
+        $results = $engine->search($builder);
+
+        $this->assertEquals([1, 3, 2], array_column($results['hits'], 'scoutKey'));
+    }
+
+    public function test_it_can_order_results_by_multiple_columns()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['category' => 'a', 'price' => 20, 'scoutKey' => 1]),
+            new SearchableModel(['category' => 'a', 'price' => 10, 'scoutKey' => 2]),
+            new SearchableModel(['category' => 'b', 'price' => 5, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->orderBy('category', 'asc');
+        $builder->orderBy('price', 'asc');
+        $results = $engine->search($builder);
+
+        $this->assertEquals([2, 1, 3], array_column($results['hits'], 'scoutKey'));
+    }
+
+    public function test_it_can_order_paginated_results()
+    {
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([
+            new SearchableModel(['price' => 30, 'scoutKey' => 1]),
+            new SearchableModel(['price' => 10, 'scoutKey' => 2]),
+            new SearchableModel(['price' => 20, 'scoutKey' => 3]),
+        ]));
+
+        $builder = new Builder(new SearchableModel, null);
+        $builder->orderBy('price', 'asc');
+        $results = $engine->paginate($builder, 2, 1);
+
+        $this->assertEquals(3, $results['total']);
+        $this->assertEquals([2, 3], array_column($results['hits'], 'scoutKey'));
+    }
+
+    public function test_it_includes_the_scout_key_name_field_in_the_indexed_record()
+    {
+        $model = Mockery::mock(new SearchableModel(['foo' => 'bar', 'scoutKey' => 1]))->makePartial();
+        $model->shouldReceive('getScoutKeyName')->andReturn('custom_key');
+
+        $engine = new ArrayEngine(new ArrayStore);
+        $engine->update(Collection::make([$model]));
+
+        $builder = new Builder(new SearchableModel, null);
+
+        $this->assertEquals(1, $engine->search($builder)['hits'][0]['custom_key']);
     }
 
     public function test_it_can_create_search_index()


### PR DESCRIPTION
ArrayEngine is now compatible with Scout v11 Builder for where clauses

Changes:

- performSearch(): split filter matching into matchesWheres(). Now handles the {field, operator, value} structure with =, !=, >, >=, <, <=, matchesKeyValueFilters() keeps the old field => values[] format.
- performSearch() now sorts matches according to $builder->orders
- update() now merges [$model->getScoutKeyName() => $model->getScoutKey()] into each stored record, matching third party engine behavior.
- Minor cleanups.
- Updated and added new tests

